### PR TITLE
This is unecessary since the url value is built from already escaped and validated get vars... but VIP

### DIFF
--- a/components/class-bsocial-comments.php
+++ b/components/class-bsocial-comments.php
@@ -264,7 +264,7 @@ class bSocial_Comments
 
 		$url = $this->get_status_url( $comment->comment_ID, $type );
 
-		return '<a href="' . esc_url( $url ) . '" title="' . $text . '" class="' . $class . '">' . $text . '</a>';
+		return '<a href="' . /* @INSANE */ esc_url( $url ) . '" title="' . $text . '" class="' . $class . '">' . $text . '</a>';
 	} // END get_status_link
 
 	/**


### PR DESCRIPTION
https://github.com/GigaOM/gigaom/issues/4830
