### PR TITLE
HOLD: Hide erroneous featured comments

### DIFF
--- a/components/templates/featured-comments.php
+++ b/components/templates/featured-comments.php
@@ -1,6 +1,12 @@
 <?php
 foreach ( $this->featured_comments as $comment_post )
 {
+	// VIP is caching the earlier query which means comments that are unfeatured might still show up here for quite awhile
+	// This is only a partial fix but it's an easy one
+	if ( ! $this->is_featured( $comment_post->comment->comment_ID ) )
+	{
+		continue;
+	} // END if
 	?>
 	<div class="featured-comment" data-comment-id="<?php echo absint( $comment_post->comment->comment_ID ); ?>">
 		<?php echo $this->get_featured_comment_text( $comment_post->comment->comment_ID ); ?>


### PR DESCRIPTION
Small tweak to hide unfeatured comments from featured box when they've been returned by a cached VIP query.

https://github.com/GigaOM/gigaom/issues/5097
https://github.com/GigaOM/gigaom/issues/5104

Related:
https://github.com/GigaOM/gigaom-plugins/pull/2536
