### PR TITLE
Dealing with `get_featured_comment_posts` cache issues:

### DIFF
--- a/components/class-bsocial-comments-featured.php
+++ b/components/class-bsocial-comments-featured.php
@@ -546,6 +546,6 @@ class bSocial_Comments_Featured
 	 */
 	public function delete_featured_comment_posts_cache( $post_id )
 	{
-		return wp_cache_delete( $comment->comment_post_ID, $this->id_base );
+		return wp_cache_delete( $post_id, $this->id_base );
 	} // END delete_featured_comment_posts_cache
 }// END bSocial_Comments_Featured


### PR DESCRIPTION
- Simplified arguments for `get_featured_comment_posts` since we weren't using the additional ones anyway
  - post_id is now the only argument
- Cache key for `get_featured_comment_posts` is post_id
- Cache is cleared on unfeature/feature comment for a given parent post_id

https://github.com/GigaOM/gigaom/issues/5097
https://github.com/GigaOM/gigaom/issues/5104
