### PR TITLE
A bit more tweaking of how statuses are registered and handled

### DIFF
--- a/components/class-bsocial-comments-feedback.php
+++ b/components/class-bsocial-comments-feedback.php
@@ -51,9 +51,10 @@ class bSocial_Comments_Feedback
 	public function init()
 	{
 		$args = array(
-			'label'                  => 'Feedback',
-			'label_count'            => _n_noop('Feedback <span class="count">(%s)</span>', 'Feedback <span class="count">(%s)</span>'),
-			'show_in_admin_all_list' => FALSE,
+			'label'             => 'Feedback',
+			'label_count'       => _n_noop('Feedback <span class="count">(%s)</span>', 'Feedback <span class="count">(%s)</span>'),
+			'status_links_show' => FALSE,
+			'include_in_all'    => TRUE,
 		);
 
 		bsocial_comments()->register()->comment_status( 'feedback', $args );

--- a/components/class-bsocial-comments-register.php
+++ b/components/class-bsocial-comments-register.php
@@ -125,10 +125,11 @@ class bSocial_Comments_Register
 	public function comment_status( $status, $args = array() )
 	{
 		$defaults = array(
-			'label'                  => FALSE,
-			'label_count'            => FALSE,
-			'public'                 => FALSE,
-			'show_in_admin_all_list' => NULL,
+			'label'             => FALSE,
+			'label_count'       => FALSE,
+			'public'            => FALSE,
+			'status_links_show' => TRUE,
+			'include_in_all'    => FALSE,
 		);
 
 		$args = wp_parse_args( $args, $defaults );
@@ -142,7 +143,7 @@ class bSocial_Comments_Register
 			return new WP_Error( 'comment_status_too_long', 'Comment statuses cannot exceed 20 characters in length' );
 		} // END if
 
-		if ( NULL === $args->show_in_admin_all_list  )
+		if ( NULL === $args->status_links_show )
 		{
 			$args->show_in_admin_all_list = $args->public;
 		}
@@ -338,7 +339,7 @@ class bSocial_Comments_Register
 				continue;
 			} // END if
 
-			if ( ! isset( $status_links[ $status->name ] ) && $status->show_in_admin_all_list )
+			if ( ! isset( $status_links[ $status->name ] ) && $status->status_links_show )
 			{
 				$status_links[ $status->name ] = $this->get_status_link( $status->name, $status->label_count );
 			} // END if
@@ -534,6 +535,17 @@ class bSocial_Comments_Register
 			return $clauses;
 		} // END if
 
+		// Create args for $wpdb->prepare out of statuses that have include_in_all set to TRUE
+		$prepare_args = array();
+
+		foreach ( $this->comment_statuses as $status )
+		{
+			if ( $status->include_in_all )
+			{
+				$prepare_args[] = $status->name;
+			} // END if
+		} // END foreach
+
 		// Build status clause
 		$status_clause = '';
 
@@ -541,8 +553,6 @@ class bSocial_Comments_Register
 		{
 			$status_clause .= " OR comment_approved = '%s'";
 		} // END for
-
-		$prepare_args = array_keys( $this->comment_statuses );
 
 		// Add the status clause to the begining fo the prepare arguments
 		array_unshift( $prepare_args, trim( $status_clause ) );


### PR DESCRIPTION
- Added include_in_all toggle for whether to adjust 'all' comment status queries to include a specific custom comment status
- Renamed show_in_admin_all_list to status_links_show which I think makes a bit more sense.
