### PR TITLE
Reset flag reason form after submit

### DIFF
--- a/components/js/bsocial-comments.js
+++ b/components/js/bsocial-comments.js
@@ -263,6 +263,10 @@ if ( 'undefined' === typeof bsocial_comments.event ) {
 		} else {
 			this.set_flag_state( $comment.attr( 'data-comment-id' ), 'flag' );
 		}//end else
+		//reset the form ( deselect radio and clear textarea )
+		$form.find( 'form' )[0].reset();
+		//have to hide the text area - and that is based on the data-selected-reason atribute
+		$form.find( 'form' ).attr( 'data-selected-reason', '' );
 		//re-disable the button see https://github.com/GigaOM/gigaom/issues/5267
 		$form.find( '.comment-flag-confirm' ).prop( { 'disabled': true } );
 


### PR DESCRIPTION
Applies to https://github.com/GigaOM/gigaom/issues/5280

Before screens in ticket.
_Test process_ 
1. click flag icon 
1. select Other, enter text
1. click "Flag" button
1. Give it a sec and un-flag. 
1. Click "Flag" again should see:
![screen shot 2014-09-11 at 10 01 51 am](https://cloud.githubusercontent.com/assets/929375/4235014/38c2cbe4-39bc-11e4-9a6b-e851ef22ed04.png)
repeat with another option ("Spam"), result should be the same.
