### PR TITLE
Wrong variable

### DIFF
--- a/components/class-bsocial-comments-feedback.php
+++ b/components/class-bsocial-comments-feedback.php
@@ -913,7 +913,7 @@ class bSocial_Comments_Feedback
 	public function send_flag_email( $feedback_id, $email )
 	{
 		$feedback = get_comment( $feedback_id );
-		$post     = get_post( $comment->comment_post_ID );
+		$post     = get_post( $feedback->comment_post_ID );
 
 		if ( 'flag' != $feedback->comment_type )
 		{

--- a/components/templates/flag-notification-email.php
+++ b/components/templates/flag-notification-email.php
@@ -12,4 +12,4 @@ Flagged comment:
 
 
 View flagged comment:
-<?php echo esc_url_raw( get_comment_link( $feedback->comment_parent ) ); ?>
+<?php echo esc_url_raw( get_comment_link( $feedback->comment_parent ) );


### PR DESCRIPTION
Applies to https://github.com/GigaOM/gigaom/issues/5398

Wrong variable. `$comment` is undefined here.

Switch to `$feedback` as in the other email notification function:
![screen shot 2014-09-26 at 12 02 08 pm](https://cloud.githubusercontent.com/assets/929375/4423630/7c48356c-4596-11e4-81da-7d308a49df1a.png)
