### PR TITLE
Use home_url rather than admin_url to prevent cross-domain ajax

### DIFF
--- a/components/class-bsocial-comments.php
+++ b/components/class-bsocial-comments.php
@@ -75,7 +75,7 @@ class bSocial_Comments
 
 		$data = array(
 			'nonce' => wp_create_nonce( 'bsocial-comment-feedback' ),
-			'endpoint' => home_url( 'wp-admin/admin-ajax.php' ),
+			'endpoint' => is_admin() ? admin_url( 'admin-ajax.php' ) : home_url( 'wp-admin/admin-ajax.php' ),
 			'logged_in_as' => get_current_user_id(),
 		);
 


### PR DESCRIPTION
This particular thing was fixed for a few other ajax URLs but the endpoint that is used while fetching feedback states for a logged in user was still having requests made cross-domain.  This wasn't a problem on local VMs, but it was on VIP where the dashboard has a different domain than the front end.

Example: `wpcom.gostage.it` (front end) vs `gigaomstaging.wordpress.com` (backend)

See: https://github.com/GigaOM/gigaom/issues/5446
