### PR TITLE
Remove <h2> from flag dialog

### DIFF
--- a/components/class-bsocial-comments-feedback.php
+++ b/components/class-bsocial-comments-feedback.php
@@ -751,7 +751,7 @@ class bSocial_Comments_Feedback
 	public function feedback_info( $comment, $args )
 	{
 		$message_logged_out = '<p>Sign in to %1$s this comment</p>';
-		$message_logged_in = '<h2>Reason for flagging this comment:</h2>';
+		$message_logged_in = '<header>Reason for flagging this comment:</header>';
 
 		$reasons = bsocial_comments()->options()->reasons;
 


### PR DESCRIPTION
Applies to https://github.com/GigaOM/gigaom/issues/5287

Changes `<h2>` to `<header>`

![screen shot 2014-10-20 at 5 29 03 pm](https://cloud.githubusercontent.com/assets/929375/4709597/8dcf0014-58a0-11e4-8b3f-f76958fd3073.png)
#### Requires Styles

https://github.com/GigaOM/gigaom/pull/5615
