### PR TITLE
Don't destructively include featured comments

### DIFF
--- a/components/class-bsocial-comments-featured.php
+++ b/components/class-bsocial-comments-featured.php
@@ -81,8 +81,8 @@ class bSocial_Comments_Featured
 
 		$post_type_config = array(
 			'labels' => array(
-				'name' => 'Featured Comments',
-				'singular_name' => 'Featured Comment',
+				'name' => 'Featured comments',
+				'singular_name' => 'Featured comment',
 			),
 			'supports' => array(
 				'title',


### PR DESCRIPTION
When featured comments are set to display in a waterfall, featured comments were added regardless of the type of waterfall - which was causing them (and posts of the `post` post type) to be displayed on archive pages where they didn't belong.

This changeset ensures that featured comments are only added to loops where A) `post_type` isn't specified or B) where the `post` post type appears in the `post_type` array.
