### PR TITLE
Don't hijack page queries with featured comment query modification

### DIFF
--- a/components/class-bsocial-comments-featured.php
+++ b/components/class-bsocial-comments-featured.php
@@ -111,6 +111,7 @@ class bSocial_Comments_Featured
 			bsocial_comments()->options()->featured_comments->add_to_waterfall
 			&& ! is_admin()
 			&& $query->is_main_query()
+			&& empty( $query->query_vars['pagename'] )
 		)
 		{
 			$post_types = (array) $query->query_vars['post_type'];


### PR DESCRIPTION
The logic that injected featured comments into the query vars was too aggressive and was doing so on WP pages - causing a 404.
