### PR TITLE
Don't attempt to rewrite the query if we're on an attachment page

### DIFF
--- a/components/class-bsocial-comments-featured.php
+++ b/components/class-bsocial-comments-featured.php
@@ -112,6 +112,7 @@ class bSocial_Comments_Featured
 			&& ! is_admin()
 			&& $query->is_main_query()
 			&& empty( $query->query_vars['pagename'] )
+			&& empty( $query->query_vars['attachment'] )
 		)
 		{
 			$post_types = (array) $query->query_vars['post_type'];


### PR DESCRIPTION
The query manipulation function is too aggressive and causes the attachment pages to infinitely redirect. Let's exclude attachment queries from manipulation.
